### PR TITLE
Use absolute imports for imports within nested modules

### DIFF
--- a/src/@types/i18next.d.ts
+++ b/src/@types/i18next.d.ts
@@ -1,4 +1,4 @@
-import { defaultNS, resources } from "../i18n";
+import { defaultNS, resources } from "@/i18n";
 
 declare module "i18next" {
   interface CustomTypeOptions {

--- a/src/@types/resources.ts
+++ b/src/@types/resources.ts
@@ -1,6 +1,6 @@
-import fallback from "../i18n/locales/en/fallback.json";
-import ns1 from "../i18n/locales/en/ns1.json";
-import ns2 from "../i18n/locales/en/ns2.json";
+import fallback from "@/i18n/locales/en/fallback.json";
+import ns1 from "@/i18n/locales/en/ns1.json";
+import ns2 from "@/i18n/locales/en/ns2.json";
 
 const resources = {
   fallback,

--- a/src/components/Rating.tsx
+++ b/src/components/Rating.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Text, VStack } from "@chakra-ui/react";
-import useRatingStore from "../stores/store";
+import useRatingStore from "@/stores/store";
 
 const Rating: React.FC = () => {
   const rating = useRatingStore((state) => state.rating);

--- a/src/components/SayHello.tsx
+++ b/src/components/SayHello.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Text } from "@chakra-ui/react";
 
 type Props = {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { Box, Center, Text } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import SayHello from "../../components/SayHello";
+import SayHello from "@/components/SayHello";
 
 function HomePage() {
   const { t } = useTranslation();

--- a/src/pages/rating/RatingPage.tsx
+++ b/src/pages/rating/RatingPage.tsx
@@ -1,5 +1,5 @@
 import { Box, Center } from "@chakra-ui/react";
-import Rating from "../../components/Rating";
+import Rating from "@/components/Rating";
 
 function RatingPage() {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src", "src/i18n.ts"],
   "references": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,8 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: [{ find: "@", replacement: "/src" }],
+  },
   plugins: [react()],
 });


### PR DESCRIPTION
Using absolute imports for nested modules in a React app offers benefits as your project grows. Absolute imports start from the project's root, enhancing readability and avoiding relative path complexity. Here's why it's beneficial:

1. **Readability**: Imports like `import Component from '@/components/Component'` clarify module locations without relative path tracing.

2. **Simplicity**: Deep project structures make relative imports with `../` cumbersome. Absolute imports remove this complexity.

3. **Refactoring**: Absolute imports maintain paths during project reorganization, reducing import path breakage.
